### PR TITLE
Add a cached data source to protect databases from health check volume

### DIFF
--- a/data_source_test.go
+++ b/data_source_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCachedDataSource_CanReuseAndExpireGetNodeInfo(t *testing.T) {
+	fds := new(fakeDataSource)
+	ds := NewCachedDataSource(fds)
+	cds := ds.(*cachedDataSource)
+	cds.cacheTTL = time.Millisecond * 10
+
+	if cds.cachedGetNodeInfo != nil || time.Now().Before(cds.cachedGetNodeInfoExpiresAt) {
+		t.Fatal("No cache should be set after initialize")
+	}
+
+	// Read from data source
+	cds.GetNodeInfo()
+	if cds.cachedGetNodeInfo == nil {
+		t.Fatal("Cache was not set after calling GetNodeInfo")
+	}
+	if cds.cachedGetNodeInfoExpiresAt.Before(time.Now()) {
+		t.Fatal("Cache expiration time was not set after calling GetNodeInfo")
+	}
+
+	// Read from cache (update value before to verify the read is cached)
+	fds.byteLag = 1337
+	nodeInfo, _ := cds.GetNodeInfo()
+	if nodeInfo != cds.cachedGetNodeInfo && nodeInfo.ByteLag != 0 {
+		t.Fatal("Did not use the cached GetNodeInfo value when cached read was expected")
+	}
+
+	// Wait for cache to expire
+	time.Sleep(cds.cacheTTL)
+	if !cds.cachedGetNodeInfoExpiresAt.Before(time.Now()) {
+		t.Fatal("Need to wait longer before cache will expire")
+	}
+
+	// Read from data source
+	nodeInfo, _ = cds.GetNodeInfo()
+	if cds.cachedGetNodeInfo.ByteLag != 1337 {
+		t.Fatal("Cache was not successfully expired")
+	}
+}
+
+func TestCachedDataSource_CanReuseAndExpireIsInRecovery(t *testing.T) {
+	fds := new(fakeDataSource)
+	ds := NewCachedDataSource(fds)
+	cds := ds.(*cachedDataSource)
+	cds.cacheTTL = time.Millisecond * 10
+
+	if cds.cachedIsInRecovery == true || time.Now().Before(cds.cachedIsInRecoveryExpiresAt) {
+		t.Fatal("No cache should be set after initialize")
+	}
+
+	// Read from data source
+	cds.IsInRecovery()
+	if cds.cachedIsInRecoveryExpiresAt.Before(time.Now()) {
+		t.Fatal("Cache expiration time was not set after calling IsInRecovery")
+	}
+
+	// Read from cache (update value before to verify the read is cached)
+	isInRecovery, _ := cds.IsInRecovery()
+	if isInRecovery != cds.cachedIsInRecovery {
+		t.Fatal("Did not use the cached IsInRecovery value when cached read was expected")
+	}
+
+	// Wait for cache to expire
+	time.Sleep(cds.cacheTTL)
+	if !cds.cachedIsInRecoveryExpiresAt.Before(time.Now()) {
+		t.Fatal("Need to wait longer before cache will expire")
+	}
+
+	// Read from data source
+	isInRecovery, _ = cds.IsInRecovery()
+	if cds.cachedIsInRecoveryExpiresAt.Before(time.Now()) {
+		t.Fatal("Cache expiration time was not set after calling IsInRecovery")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,10 @@ func main() {
 	}
 	defer ds.Close()
 
+	// Wrap the data source in a caching layer to prevent
+	// many concurrent health-checks from bogging things down.
+	ds = NewCachedDataSource(ds)
+
 	// Fake data source
 	fds := new(fakeDataSource)
 	fds = fds

--- a/mocks.go
+++ b/mocks.go
@@ -1,18 +1,32 @@
 package main
 
 import (
-	"fmt"
 	"time"
+
+	"gopkg.in/volatiletech/null.v6"
 )
 
-type fakeDataSource struct{}
+type fakeDataSource struct {
+	byteLag int64
+}
 
 func (fdr *fakeDataSource) Close() error {
 	return nil
 }
 
 func (fdr *fakeDataSource) GetNodeInfo() (*NodeInfo, error) {
-	return nil, fmt.Errorf("err: not implemented")
+	return &NodeInfo{
+		State:               1,
+		PostmasterStartTime: "2020-11-12 10:55:55.073 EST",
+		Role:                "primary",
+		Xlog: &XlogInfo{
+			Location:         137936246584,
+			ReceivedLocation: 137936246408,
+			ReplayedLocation: null.NewInt64(137936246408, true),
+			Paused:           false,
+		},
+		ByteLag: fdr.byteLag,
+	}, nil
 }
 
 func (fdr *fakeDataSource) IsInRecovery() (bool, error) {


### PR DESCRIPTION
I excluded stat replication and replication slots from the tests because
we're probably going to remove those soon anyways.

When we wired this up to haproxy in prod we saw some db conn spikes. Did not impact db load but was making some connection charts look strange. This change will make it so we only perform a real db check once a second. Obviously caching a health check is a strange concept, but our health-checks run every 2 seconds so I think this is a safe change.

@benschinn 