### PR TITLE
wal_status and safe_wal_size columns added in postgres13

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -50,6 +50,7 @@ type PgStatWalReceiver struct {
 	ReceivedLsn        string `db:"received_lsn"`
 	ReceivedTli        string `db:"received_tli"`
 	ReceiveStartLsn    string `db:"receive_start_lsn"`
+	WrittenLsn         string `db:"written_lsn"`
 	ReceiveStartTli    string `db:"receive_start_tli"`
 	LastMsgSendTime    string `db:"last_msg_send_time"`
 	LastMsgReceiptTime string `db:"last_msg_receipt_time"`

--- a/data_source.go
+++ b/data_source.go
@@ -40,6 +40,8 @@ type PgReplicationSlot struct {
 	CatalogXmin       string      `db:"catalog_xmin"`
 	RestartLsn        string      `db:"restart_lsn"`
 	ConfirmedFlushLsn string      `db:"confirmed_flush_lsn"`
+	WalStatus         string      `db:"wal_status"`
+	SafeWalSize       null.String `db:"safe_wal_size"`
 }
 
 type PgStatWalReceiver struct {

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -4,4 +4,5 @@ database: postgres
 user: postgres
 sslmode: disable
 binary_parameters: yes
-port: 9432
+port: 7432
+max_hop: 3


### PR DESCRIPTION
Updated to postgres13 on some nodes and seeing this error:
```
Feb 15 12:15:36 sd-prod-postgres202 pgreba[3338]: 2021/02/15 12:15:36 Error getting pg_current_wal_lsn: missing destination name written_lsn in *main.PgStatWalReceiver
Feb 15 12:15:37 sd-prod-postgres202 pgreba[6986]: 2021/02/15 12:15:37 Listening on :8000
Feb 15 12:15:37 sd-prod-postgres202 pgreba[6986]: 2021/02/15 12:15:37 Error getting pg_current_wal_lsn: missing destination name written_lsn in *main.PgStatWalReceiver
Feb 15 12:15:37 sd-prod-postgres202 pgreba[8504]: 2021/02/15 12:15:37 Listening on :8000
Feb 15 12:15:37 sd-prod-postgres202 pgreba[8504]: 2021/02/15 12:15:37 Error getting pg_current_wal_lsn: missing destination name written_lsn in *main.PgStatWalReceiver
Feb 15 12:15:37 sd-prod-postgres202 pgreba[10113]: 2021/02/15 12:15:37 Listening on :8000
Feb 15 12:15:37 sd-prod-postgres202 pgreba[10113]: 2021/02/15 12:15:37 Error getting pg_current_wal_lsn: missing destination name written_lsn in *main.PgStatWalReceiver
Feb 15 12:15:37 sd-prod-postgres202 pgreba[11487]: 2021/02/15 12:15:37 Listening on :8000
Feb 15 12:15:37 sd-prod-postgres202 pgreba[11487]: 2021/02/15 12:15:37 Error getting pg_current_wal_lsn: missing destination name written_lsn in *main.PgStatWalReceiver
```

This MR should fix this.


Tested that it doesn't break pg10:

```
$ pgvm cluster list                 
cluster in current environment (10.2):
    my_cluster  is online  at port 5433
$ cat examples/local.yml | grep port
port: 5433
$ curl localhost:8000/replica       
{"state":1,"postmaster_start_time":"2021-02-15 13:06:09.628 EST","role":"primary","xlog":{"location":22941688,"received_location":0,"replayed_location":null,"replayed_timestamp":null,"paused":false},"replication":[],"byte_lag":0}
```


Also tested that it doesn't break in pg10 replica:
```
psql -U postgres -p 7432 -h localhost
postgres=# select version();
                                                     version                                                      
------------------------------------------------------------------------------------------------------------------
 PostgreSQL 10.2 on x86_64-apple-darwin19.6.0, compiled by Apple clang version 12.0.0 (clang-1200.0.31.1), 64-bit
(1 row)

postgres=# select pg_is_in_recovery();
 pg_is_in_recovery 
-------------------
 t
(1 row)

$ cat examples/config.yml | grep port
port: 7432

$ curl -s http://localhost:8000/replica | jq .
{
  "state": 0,
  "postmaster_start_time": "2021-02-15 14:25:30.218 EST",
  "role": "replica",
  "xlog": {
    "location": 0,
    "received_location": 83889320,
    "replayed_location": 83889320,
    "replayed_timestamp": null,
    "paused": false
  },
  "replication": [],
  "byte_lag": 0
}

```