### PR TITLE
add flushed lsn col

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -40,6 +40,7 @@ type PgReplicationSlot struct {
 	CatalogXmin       string      `db:"catalog_xmin"`
 	RestartLsn        string      `db:"restart_lsn"`
 	ConfirmedFlushLsn string      `db:"confirmed_flush_lsn"`
+  //pg13 columns
 	WalStatus         string      `db:"wal_status"`
 	SafeWalSize       null.String `db:"safe_wal_size"`
 }
@@ -50,7 +51,6 @@ type PgStatWalReceiver struct {
 	ReceivedLsn        string `db:"received_lsn"`
 	ReceivedTli        string `db:"received_tli"`
 	ReceiveStartLsn    string `db:"receive_start_lsn"`
-	WrittenLsn         string `db:"written_lsn"`
 	ReceiveStartTli    string `db:"receive_start_tli"`
 	LastMsgSendTime    string `db:"last_msg_send_time"`
 	LastMsgReceiptTime string `db:"last_msg_receipt_time"`
@@ -58,6 +58,9 @@ type PgStatWalReceiver struct {
 	LatestEndTime      string `db:"latest_end_time"`
 	SlotName           string `db:"slot_name"`
 	ConnInfo           string `db:"conninfo"`
+  //pg13 columns
+	WrittenLsn         string `db:"written_lsn"`
+	FlushedLsn         string `db:"flushed_lsn"`
 }
 
 type PgStatReplication struct {

--- a/data_source.go
+++ b/data_source.go
@@ -40,9 +40,9 @@ type PgReplicationSlot struct {
 	CatalogXmin       string      `db:"catalog_xmin"`
 	RestartLsn        string      `db:"restart_lsn"`
 	ConfirmedFlushLsn string      `db:"confirmed_flush_lsn"`
-  //pg13 columns
-	WalStatus         string      `db:"wal_status"`
-	SafeWalSize       null.String `db:"safe_wal_size"`
+	//pg13 columns
+	WalStatus   string      `db:"wal_status"`
+	SafeWalSize null.String `db:"safe_wal_size"`
 }
 
 type PgStatWalReceiver struct {
@@ -58,9 +58,9 @@ type PgStatWalReceiver struct {
 	LatestEndTime      string `db:"latest_end_time"`
 	SlotName           string `db:"slot_name"`
 	ConnInfo           string `db:"conninfo"`
-  //pg13 columns
-	WrittenLsn         string `db:"written_lsn"`
-	FlushedLsn         string `db:"flushed_lsn"`
+	//pg13 columns
+	WrittenLsn string `db:"written_lsn"`
+	FlushedLsn string `db:"flushed_lsn"`
 }
 
 type PgStatReplication struct {


### PR DESCRIPTION
argh! missed one column! new error:
```
Feb 15 21:10:03 sa-qa-postgres201 pgreba[26688]: 2021/02/15 21:10:03 Listening on :8000
Feb 15 21:10:03 sa-qa-postgres201 pgreba[26688]: 2021/02/15 21:10:03 Error getting pg_current_wal_lsn: missing destination name flushed_lsn in *main.PgStatWalReceiver
```

test for pg10 replica:

```
$ psql -U postgres -p 7432 -h localhost
psql (10.2)
Type "help" for help.

postgres=# select pg_is_in_recovery();
 pg_is_in_recovery 
------------------- t
(1 row)

postgres=# select version();
                                                     version                                                      ------------------------------------------------------------------------------------------------------------------
 PostgreSQL 10.2 on x86_64-apple-darwin19.6.0, compiled by Apple clang version 12.0.0 (clang-1200.0.31.1), 64-bit
(1 row)
$ cat examples/config.yml | grep port
port: 7432

$ ./pgreba examples/config.yml
2021/02/15 16:26:01 Listening on :8000
::1 - - [15/Feb/2021:16:26:06 -0500] "GET /replica HTTP/1.1" 200 234
```


test for pg10 primary:

```
$ psql -U postgres -p 9432 -h localhost
psql (10.2)
Type "help" for help.

postgres=# select pg_is_in_recovery();
 pg_is_in_recovery 
-------------------
 f
(1 row)

postgres=# postgres=# select version();
                                                     version                                                      
------------------------------------------------------------------------------------------------------------------
 PostgreSQL 10.2 on x86_64-apple-darwin19.6.0, compiled by Apple clang version 12.0.0 (clang-1200.0.31.1), 64-bit
(1 row)

$ cat examples/config.yml | grep port
port: 9432

$ ./pgreba examples/config.yml
2021/02/15 16:29:31 Listening on :8000
::1 - - [15/Feb/2021:16:29:40 -0500] "GET / HTTP/1.1" 200 510
::1 - - [15/Feb/2021:16:29:46 -0500] "GET /primary HTTP/1.1" 200 510
```