### PR TITLE
adding sender_host and sender_port columns

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -62,7 +62,7 @@ type PgStatWalReceiver struct {
 	WrittenLsn string `db:"written_lsn"`
 	FlushedLsn string `db:"flushed_lsn"`
 	SenderHost string `db:"sender_host"`
-	SenderPort string `db""sender_port"`
+  SenderPort string `db:"sender_port"`
 }
 
 type PgStatReplication struct {

--- a/data_source.go
+++ b/data_source.go
@@ -61,6 +61,8 @@ type PgStatWalReceiver struct {
 	//pg13 columns
 	WrittenLsn string `db:"written_lsn"`
 	FlushedLsn string `db:"flushed_lsn"`
+  SenderHost string `db:"sender_host"`
+  SenderPort string `db""sender_port"`
 }
 
 type PgStatReplication struct {

--- a/data_source.go
+++ b/data_source.go
@@ -61,8 +61,8 @@ type PgStatWalReceiver struct {
 	//pg13 columns
 	WrittenLsn string `db:"written_lsn"`
 	FlushedLsn string `db:"flushed_lsn"`
-  SenderHost string `db:"sender_host"`
-  SenderPort string `db""sender_port"`
+	SenderHost string `db:"sender_host"`
+	SenderPort string `db""sender_port"`
 }
 
 type PgStatReplication struct {

--- a/data_source.go
+++ b/data_source.go
@@ -62,7 +62,7 @@ type PgStatWalReceiver struct {
 	WrittenLsn string `db:"written_lsn"`
 	FlushedLsn string `db:"flushed_lsn"`
 	SenderHost string `db:"sender_host"`
-  SenderPort string `db:"sender_port"`
+	SenderPort string `db:"sender_port"`
 }
 
 type PgStatReplication struct {


### PR DESCRIPTION
Getting this error:
```
Feb 16 14:55:47 sa-qa-postgres201 pgreba[26747]: 2021/02/16 14:55:47 Listening on :8000
Feb 16 14:55:47 sa-qa-postgres201 pgreba[26747]: 2021/02/16 14:55:47 Error getting pg_current_wal_lsn: missing destination name sender_host in *main.PgStatWalReceiver
```

Pretty sure these are the last two columns that are missing.


Unfortunately, I failed to test on pg13 replica cluster locally. I tried several times to get patroni to start a pg13 replica, but only could get pg10 replicas going. I did test however adding a temporary`pgreba-linux-amd64.tar.gz`built from the changes from this PR to the latest release, and testing it on a QA pg13 replica node and seems to fix the issue
```
$ journalctl -t pgreba
...
Feb 16 15:25:41 sa-qa-postgres201 pgreba[3400]: 10.66.33.195 - - [16/Feb/2021:15:25:41 +0000] "GET /primary HTTP/1.0" 503 271                                                                                                                                 
Feb 16 15:25:41 sa-qa-postgres201 pgreba[3400]: 10.66.33.195 - - [16/Feb/2021:15:25:41 +0000] "GET /replica?max_allowable_byte_lag=200000000 HTTP/1.0" 200 271   
```
