### PR TITLE
Send logging to file, not stdout. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,7 +111,6 @@ func main() {
 
 	router := mux.NewRouter()
 	router.Use(func(next http.Handler) http.Handler {
-		log.SetOutput(os.Stdout)
 		return handlers.LoggingHandler(log.Writer(), next)
 	})
 

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func main() {
 
 	router := mux.NewRouter()
 	router.Use(func(next http.Handler) http.Handler {
+		log.SetOutput(os.Stdout)
 		return handlers.LoggingHandler(log.Writer(), next)
 	})
 

--- a/main.go
+++ b/main.go
@@ -102,6 +102,13 @@ func main() {
 	hc := NewHealthChecker(ds)
 	hcs := &HealthCheckWebService{healthChecker: hc}
 
+	file, err := os.OpenFile("/var/log/pgreba/pgreba.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+	log.SetOutput(file)
+
 	router := mux.NewRouter()
 	router.Use(func(next http.Handler) http.Handler {
 		log.SetOutput(os.Stdout)


### PR DESCRIPTION
Prevent logging from going to STDOUT and instead go to a file. 

By default all logging goes to `/var/log/user.log` which on a busy system can generate logs too quickly and take a lot of space. 