### PR TITLE
Print error and don't exit

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -260,11 +260,13 @@ FROM
 	pgCurrentWalLsn, err := ds.getPgCurrentWalLsn(ds.cfg.MaxHop, db)
 	if err != nil {
 		log.Println("Error getting pg_current_wal_lsn:", err)
+		return nil, err
 	}
 
 	pgLastWalLsn, err := ds.getPgLastWalReplayLsn()
 	if err != nil {
 		log.Println("Error getting pg_last_wal_replay_lsn:", err)
+		return nil, err
 	}
 	// Skip the byte lag checks if the last wal lsn is empty
 	if pgLastWalLsn == "" {
@@ -274,6 +276,7 @@ FROM
 	byteLag, err := ds.getPgWalLsnDiff(pgCurrentWalLsn, pgLastWalLsn)
 	if err != nil {
 		log.Println("Error getting pg_wal_lsn_diff:", err)
+		return nil, err
 	}
 
 	nodeInfo.ByteLag = byteLag

--- a/data_source.go
+++ b/data_source.go
@@ -259,12 +259,12 @@ FROM
 
 	pgCurrentWalLsn, err := ds.getPgCurrentWalLsn(ds.cfg.MaxHop, db)
 	if err != nil {
-		log.Fatalln("Error getting pg_current_wal_lsn:", err)
+		log.Println("Error getting pg_current_wal_lsn:", err)
 	}
 
 	pgLastWalLsn, err := ds.getPgLastWalReplayLsn()
 	if err != nil {
-		log.Fatalln("Error getting pg_last_wal_replay_lsn:", err)
+		log.Println("Error getting pg_last_wal_replay_lsn:", err)
 	}
 	// Skip the byte lag checks if the last wal lsn is empty
 	if pgLastWalLsn == "" {
@@ -273,7 +273,7 @@ FROM
 
 	byteLag, err := ds.getPgWalLsnDiff(pgCurrentWalLsn, pgLastWalLsn)
 	if err != nil {
-		log.Fatalln("Error getting pg_wal_lsn_diff:", err)
+		log.Println("Error getting pg_wal_lsn_diff:", err)
 	}
 
 	nodeInfo.ByteLag = byteLag


### PR DESCRIPTION
We are seeing this error occur:

```
Error getting pg_current_wal_lsn: sql: no rows in resulting set
```

Then pgreba exits with status 1.

Removing `Fatalln` should fix this issue.

cc: @skunkworker @film42 