### PR TITLE
always return byte lag 0 for primary

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -254,7 +254,7 @@ FROM
 	// Make patroni api tweaks
 	if nodeInfo.State == 0 {
 		nodeInfo.Role = "replica"
-		
+
 		pgCurrentWalLsn, err := ds.getPgCurrentWalLsn(ds.cfg.MaxHop, db)
 		if err != nil {
 			log.Println("Error getting pg_current_wal_lsn:", err)
@@ -353,7 +353,7 @@ func (ds *pgDataSource) getPgLastWalReplayLsn() (string, error) {
 	}
 
 	pgLastWalLsn := null.String{}
-	err := db.Get(&pgLastWalLsn, "select case when pg_catalog.pg_is_in_recovery() then pg_catalog.pg_last_wal_replay_lsn() else pg_catalog.pg_current_wal_lsn() end")
+	err := db.Get(&pgLastWalLsn, "select pg_last_wal_replay_lsn()")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
not sure this makes sense, but i was confused by the continually growing byte lag when querying `/replica` on a primary db:

```
$ curl -s http://127.0.0.1:8000/replica?max_allowable_byte_lag=200000000 | jq .
{
  "state": 2,
  "postmaster_start_time": "2022-02-15 21:26:18.612 UTC",
  "role": "primary",
  "xlog": {
    "location": 141195053033960,
    "received_location": 137144846730552,
    "replayed_location": 137144846730552,
    "replayed_timestamp": "2022-03-02 07:23:08.904 UTC",
    "paused": false
  },
  "replication": [
    {
      ...
    }
  ],
  "byte_lag": 4050206303408
}
```

this makes it to the byte lag on a primary is always 0.